### PR TITLE
Add two new methods : fetch_nearest_up & fest_nearest_down

### DIFF
--- a/IntervalTree.xs
+++ b/IntervalTree.xs
@@ -36,6 +36,12 @@ class SV_ptr {
       if (sv) SvREFCNT_inc(sv);
       return *this;
     }
+    bool operator!=(SV_ptr &ptr) {
+      return sv != ptr.get();
+    }
+    bool defined() {
+      return sv != 0;
+    }
     SV * get() {
       return sv; 
     }
@@ -100,6 +106,30 @@ PerlIntervalTree::str()
     std::string str = THIS->str();
     const char *tree = str.c_str();
     RETVAL = newSVpv(tree, 0);
+  OUTPUT:
+    RETVAL
+
+SV *
+PerlIntervalTree::fetch_nearest_up(long value)
+  CODE:
+    SV_ptr ptr = THIS->fetch_nearest_up(value);
+    SV *ret = ptr.get();
+    SvREFCNT_inc(ret);
+    RETVAL = ret;
+    if (RETVAL == 0)
+          XSRETURN_UNDEF;
+  OUTPUT:
+    RETVAL
+
+SV *
+PerlIntervalTree::fetch_nearest_down(long value)
+  CODE:
+    SV_ptr ptr = THIS->fetch_nearest_down(value-1);
+    SV *ret = ptr.get();
+    SvREFCNT_inc(ret);
+    RETVAL = ret;
+    if (RETVAL == 0)
+          XSRETURN_UNDEF;
   OUTPUT:
     RETVAL
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -9,4 +9,5 @@ src/interval_tree.h
 src/test_main.cc
 src/Makefile
 t/Set-IntervalTree.t
+t/fetch-nearest.t
 lib/Set/IntervalTree.pm

--- a/lib/Set/IntervalTree.pm
+++ b/lib/Set/IntervalTree.pm
@@ -131,6 +131,20 @@ my $results = $tree->fetch_window($low, $high)
   $low is the lower bound of the region to query.
   $high is the upper bound of the region to query.
 
+my $nearest_up = $tree->fetch_nearest_up($query)
+
+  Search for the closest interval in upstream that does not contain the query
+  and returns the perl object associated with it.
+
+  $query is the position to use for the search
+
+my $nearest_down = $tree->fetch_nearest_down($query)
+
+  Search for the closest interval in downstream that does not contain the query
+  and returns the perl object associated with it.
+
+  $query is the position to use for the search
+
 my $removed = $tree->remove($low, $high [, optional \&coderef]);
 
   Remove items in the tree that overlap the region from $low to $high. 

--- a/t/fetch-nearest.t
+++ b/t/fetch-nearest.t
@@ -1,0 +1,21 @@
+
+use Test::More tests => 9;
+BEGIN { use_ok('Set::IntervalTree') };
+
+use strict;
+use warnings;
+
+my $tree = Set::IntervalTree->new;
+$tree->insert("A",1,2);
+$tree->insert("B",2,3);
+$tree->insert("C",6,10);
+$tree->insert("D",4,12);
+
+is($tree->fetch_nearest_up(2), "D");
+is($tree->fetch_nearest_up(5), "C");
+is($tree->fetch_nearest_up(1), "B");
+is($tree->fetch_nearest_up(7), undef);
+is($tree->fetch_nearest_down(7), "B");
+is($tree->fetch_nearest_down(3), "B");
+is($tree->fetch_nearest_down(11), "C");
+is($tree->fetch_nearest_down(1), undef);


### PR DESCRIPTION
Dear benwwbooth,

Thanks for your great work on this perl module to deal with interval queries, it is very efficient and easy to use. I have introduced two new methods (fetch_nearest_up and fetch_nearest_down) to quert the structure that would be very helpfull for my use of Set::IntervalTree.

Thanks for considering this pull request.

Best,
Jerome.
